### PR TITLE
将棋(Python)暫定最終版

### DIFF
--- a/customshogi.py
+++ b/customshogi.py
@@ -1,59 +1,52 @@
 """
 動作環境: Python3.10以上
 
-前提
-    1. 参加者が作成するものであるから、カスタマイズはコードの編集で行う
-    2. 隠蔽された実装を考えさせないようにする(挙動をシンプルにする)
-        -> でもブラックボックスが多くなるのもな...
-そもそもどのような部品の組み合わせにするか?
-(ロジック, グラフィック)/(盤, 駒)
-※駒が
-①盤(抽象)
-    二次元配列で盤(及び駒台)を表し、各要素がその升目にある駒(/何もない/盤の欠け)を表す。
-②盤(描画)
-    ①を可視化する。デザインのカスタマイズもここで行う。
-③駒(抽象)
+TODO: (モジュールの)ドキュメントをまとめる
 """
 
-# TODO: 持ち駒機能の追加(切り替え可能にする)
 # TODO: 成りの追加(設定可能にする)
+# TODO: 持ち駒機能の追加(切り替え可能にする)
+# TODO: 初手の動きの追加(設定可能にする)
+# TODO: 盤面の欠けを設定できるようにする
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
-from collections.abc import Container
+from collections.abc import Iterable, Mapping
 from enum import Enum, auto
-from typing import Any, Iterable, Mapping, Optional, Literal
+from typing import Any, Optional, Literal
 
 
-def choose_by_user(option: set[str]):
+def choose_by_user(option: set[str], *, msg="choose from following choises: "):
     """ユーザーに選択肢を表示し、選択を行わせる"""
     while True:
-        print("choose from following choises: ", end='')
-        print(*option, sep=", ")
+        print(msg, end='')
+        print(*sorted(option), sep=", ")
         choice = input()
         if choice in option:
             return choice
-        print(f"invalid choice: {choice}")
+        print(f"invalid input: {choice}")
 
 
-# 盤について課す制限
+# 盤についての前提条件
 #     - マスは正方形であり、頂点が集まるように敷き詰められている
 #     - 一マスに存在しうる駒は高々1つ
 #     - 駒はマス内もしくは駒台上にのみ存在する
 #     - 走り駒は原則、盤の欠けの上を走ることはできない
 
 
-# """盤[行][列]"""
-# 何もないマスはNone?
-
-
 class Coordinate(ABC):
-    """二次元座標の基底クラス"""
-    def __str__(self) -> str:
+    """二次元座標の基底クラス
+    座標の負の値は、負のインデックスとして解釈される。
+
+    Constructor Params:
+        y: +は前, -は後ろ
+        x: +は右, -は左
+    """
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}{self.y, self.x}"
 
-    __repr__ = __str__
+    __str__ = __repr__
 
     def __init__(self, y: int, x: int) -> None:
         if not isinstance(y, int):
@@ -65,10 +58,16 @@ class Coordinate(ABC):
 
     @property
     def y(self):
+        """前後方向の座標
+        +は前, -は後ろ
+        """
         return self.__y
 
     @property
     def x(self):
+        """左右方向の座標
+        +は右, -は左
+        """
         return self.__x
 
     def __add__(self, __o: object):
@@ -79,7 +78,6 @@ class Coordinate(ABC):
     def __copy__(self):
         return type(self)(self.y, self.x)
 
-    # TODO: なんかhashがおかしいが__eq__で動いた
     def __hash__(self) -> int:
         return hash((self.__y, self.__x, type(self)))
 
@@ -90,7 +88,11 @@ class Coordinate(ABC):
 
 class AbsoluteCoordinate(Coordinate):
     """盤面の座標を表すクラス
-    負の値は、負のインデックスとして解釈される。
+    座標の負の値は、負のインデックスとして解釈される。
+
+    Constructor Params:
+        y: +は前, -は後ろ
+        x: +は右, -は左
     """
     def __add__(self, __o: object):
         if isinstance(__o, AbsoluteCoordinate):
@@ -101,10 +103,12 @@ class AbsoluteCoordinate(Coordinate):
 
     @property
     def x_inverted(self):
+        """x座標を反転させた座標(y, x)を返す"""
         return type(self)(self.y, ~self.x)
 
     @property
     def y_inverted(self):
+        """y座標を反転させた座標(y, x)を返す"""
         return type(self)(~self.y, self.x)
 
     def __neg__(self):
@@ -112,16 +116,25 @@ class AbsoluteCoordinate(Coordinate):
 
     __invert__ = __neg__
 
+    @property
+    def full_inverted(self):
+        """x, y座標をそれぞれ反転させた座標(y, x)を返す"""
+        return -self
+
     def __pos__(self):
         return super().__copy__
 
-    @property
-    def upside_right(self):
-        return type(self)(self.x, self.y)
+    def normalize(self, board: IBoard):
+        """盤面の大きさに合わせて、負のインデックスを標準形に直す"""
+        return type(self)(self._normalizer(self.y, board.height), self._normalizer(self.x, board.width))
 
-    @property
-    def upside_left(self):
-        return type(self)(~self.x, ~self.y)
+    @staticmethod
+    def _normalizer(target: int, standard: int) -> int:
+        if target < -standard or standard <= target:
+            raise ValueError(f"target coordinate {target} is out of range{-standard, standard}")
+        if target < 0:
+            return target + standard
+        return target
 
 class RelativeCoordinate(Coordinate):
     """盤面における相対座標を表すクラス"""
@@ -135,10 +148,12 @@ class RelativeCoordinate(Coordinate):
 
     @property
     def x_inverted(self):
+        """x座標を反転させた座標(y, x)を返す"""
         return type(self)(self.y, -self.x)
 
     @property
     def y_inverted(self):
+        """y座標を反転させた座標(y, x)を返す"""
         return type(self)(-self.y, self.x)
 
     def __neg__(self):
@@ -146,38 +161,47 @@ class RelativeCoordinate(Coordinate):
 
     __invert__ = __neg__
 
+    @property
+    def full_inverted(self):
+        """x, y座標をそれぞれ反転させた座標(y, x)を返す"""
+        return -self
+
     def __pos__(self):
         return super().__copy__()
 
     @property
     def upside_right(self):
+        """直線y=xに対して対称に反転させた座標(y, x)を返す"""
         return type(self)(self.x, self.y)
 
     @property
     def upside_left(self):
+        """直線y=-xに対して対称に反転させた座標(y, x)を返す"""
         return type(self)(-self.x, -self.y)
 
 
 class Controller2P(Enum):
     """駒・ターンのコントローラーを示す
 
-    ABSENT: 空きマス
+    INDEPENDENT: その他(未使用)
     WHITE: 先手
     BLACK: 後手
 
     行列演算`@`によって、(左辺)から見た(右辺)の素性を示す`Relation2P`を返す
     """
-    ABSENT = auto()
+    INDEPENDENT = auto()
     WHITE = auto()
     BLACK = auto()
 
     def __matmul__(self, __o: object) -> Relation:
+        if self is Controller2P.INDEPENDENT:
+            raise NotImplementedError("moving independent piece is not implemented yet")
+        if __o is None:
+            return Relation.TO_BLANK
         if not isinstance(__o, Controller2P):
             raise TypeError
-        if self is Controller2P.ABSENT:
-            raise NotImplementedError("move from independent")
-        if __o is Controller2P.ABSENT:
-            return Relation.TO_BLANK
+        if __o is Controller2P.INDEPENDENT:
+            raise NotImplementedError("moving independent piece is not implemented yet")
         if self is __o:
             return Relation.FRIEND
         return Relation.ENEMY
@@ -266,14 +290,14 @@ class LeaperMove(IMove, IElementalMove):
     """Leaper(跳び駒)の動きの実装"""
     def __init__(
             self,
-            coordinates: Container[RelativeCoordinate],
+            coordinates: Iterable[RelativeCoordinate],
             *,
-            symmetry: Literal['none', 'h', 'vh', 'oct'] = 'none',
+            symmetry: Literal['none', 'lr', 'fblr', 'oct'] = 'none',
         ) -> None:
         self.__coordinates: set[RelativeCoordinate] = set(coordinates)
-        if symmetry in ('h', 'vh', 'oct'):
+        if symmetry in ('lr', 'fblr', 'oct'):
             self.__coordinates.update({coord.x_inverted for coord in self.__coordinates})
-            if symmetry in ('vh', 'oct'):
+            if symmetry in ('fblr', 'oct'):
                 self.__coordinates.update({coord.y_inverted for coord in self.__coordinates})
                 if symmetry == 'oct':
                     self.__coordinates.update({coord.upside_left for coord in self.__coordinates})
@@ -284,11 +308,11 @@ class LeaperMove(IMove, IElementalMove):
             Relation.TO_BLANK: Approachability.CONTINUE,
         }
 
-    def derive_to(
+    def derive(
             self,
-            coordinates: Container[RelativeCoordinate] = ...,
+            coordinates: Iterable[RelativeCoordinate] = ...,
             *,
-            symmetry: Literal['none', 'h', 'vh', 'oct'] = 'none',
+            symmetry: Literal['none', 'lr', 'fblr', 'oct'] = 'none',
         ) -> None:
         """自身をコピーしたものを返す
         ただし、引数が与えられたものについては上書きし、
@@ -323,7 +347,7 @@ class LeaperMove(IMove, IElementalMove):
         destinations: set[AbsoluteCoordinate] = set()
         for movement in self.coordinates_in_controller(controller):
             new_coordinate = current_coordinate + movement
-            if not board.include(new_coordinate):
+            if not board.includes(new_coordinate):
                 continue
             target_square = board[new_coordinate]
             if target_square.is_lack:
@@ -343,23 +367,26 @@ class RiderMove(IMove, IElementalMove):
             self,
             coordinate_to_dist: Mapping[RelativeCoordinate, int],
             *,
-            symmetry: Literal['none', 'h', 'vh', 'oct'] = 'none',
+            symmetry: Literal['none', 'lr', 'fblr', 'oct'] = 'none',
         ) -> None:
         self.__coordinate_to_dist: dict[RelativeCoordinate, int] = defaultdict(int, coordinate_to_dist)
 
-        def adopt_dist(a: int, b: int):
-            if a < 0 or b < 0:
-                return -1
-            return max(a, b)
-        if symmetry in ('h', 'vh', 'oct'):
+        if symmetry in ('lr', 'fblr', 'oct'):
+            def adopt_dist(a: int, b: int):
+                if a < 0 or b < 0:
+                    return -1
+                return max(a, b)
             for coord, dist in set(self.__coordinate_to_dist.items()):
-                self.__coordinate_to_dist[coord.x_inverted] = adopt_dist(self.__coordinate_to_dist[coord.x_inverted], dist)
-            if symmetry in ('vh', 'oct'):
+                self.__coordinate_to_dist[coord.x_inverted] \
+                    = adopt_dist(self.__coordinate_to_dist[coord.x_inverted], dist)
+            if symmetry in ('fblr', 'oct'):
                 for coord, dist in set(self.__coordinate_to_dist.items()):
-                    self.__coordinate_to_dist[coord.y_inverted] = adopt_dist(self.__coordinate_to_dist[coord.x_inverted], dist)
+                    self.__coordinate_to_dist[coord.y_inverted] \
+                        = adopt_dist(self.__coordinate_to_dist[coord.x_inverted], dist)
                 if symmetry == 'oct':
                     for coord, dist in set(self.__coordinate_to_dist.items()):
-                        self.__coordinate_to_dist[coord.upside_left] = adopt_dist(self.__coordinate_to_dist[coord.x_inverted], dist)
+                        self.__coordinate_to_dist[coord.upside_left] \
+                            = adopt_dist(self.__coordinate_to_dist[coord.x_inverted], dist)
 
         self.approachability_mapping = {
             Relation.FRIEND: Approachability.REJECT,
@@ -367,11 +394,11 @@ class RiderMove(IMove, IElementalMove):
             Relation.TO_BLANK: Approachability.CONTINUE,
         }
 
-    def derive_to(
+    def derive(
             self,
             coordinate_to_dist: Mapping[RelativeCoordinate, int],
             *,
-            symmetry: Literal['none', 'h', 'vh', 'oct'] = 'none',
+            symmetry: Literal['none', 'lr', 'fblr', 'oct'] = 'none',
         ) -> None:
         """自身をコピーしたものを返す
         ただし、引数が与えられたものについては上書きし、
@@ -410,8 +437,7 @@ class RiderMove(IMove, IElementalMove):
                 max_dist = max(board.height, board.width)
             for _ in range(max_dist):
                 new_coordinate += movement
-                print(new_coordinate)
-                if not board.include(new_coordinate):
+                if not board.includes(new_coordinate):
                     break
                 target_square = board[new_coordinate]
                 if target_square.is_lack:
@@ -423,13 +449,12 @@ class RiderMove(IMove, IElementalMove):
                 if self.approachability(relation).can_land:
                     destinations.add(new_coordinate)
                 if not self.approachability(relation).can_go_over:
-                    print("can't pass")
                     break
         return destinations
 
 
 class MoveParallelJoint(IMove):
-    """複数の動きを合体する"""
+    """複数の動きを合わせた動きを作る"""
     def __init__(self, *move: IMove) -> None:
         self.move = move
 
@@ -449,9 +474,13 @@ class MoveParallelJoint(IMove):
 class IPiece(ABC):
     """駒の抽象クラス"""
     def __str__(self) -> str:
-        return self.NAME
+        return f"{self.NAME}({self.controller})"
 
-    __repr__ = __str__
+    def __init__(
+            self,
+            controller: Controller2P,
+        ) -> None:
+        self.controller = controller
 
     @property
     def SYMBOL_COLORED(self):
@@ -465,9 +494,9 @@ class IPiece(ABC):
         return self.SYMBOL
 
     @property
-    @abstractmethod
     def NAME(self) -> str:
         """name of piece"""
+        return self.__class__.__name__
 
     @property
     @abstractmethod
@@ -475,22 +504,14 @@ class IPiece(ABC):
         """move definition of piece"""
 
     @property
-    @abstractmethod
     def ROYALTY(self) -> bool:
         """if True, this piece is royal"""
+        return False
 
     @property
     @abstractmethod
     def SYMBOL(self) -> str:
         """a character that represents this piece"""
-
-    def __init__(
-            self,
-            coordinate: Optional[AbsoluteCoordinate],
-            controller: Controller2P,
-        ) -> None:
-        self.coordinate = coordinate
-        self.controller = controller
 
     def valid_destination(
             self,
@@ -503,7 +524,7 @@ class IPiece(ABC):
         # cls.MOVEに従って動ける場所を表示する
         # -> クリックでそこに移動し、(駒を取ることを含む段数が)二段以上だったら次の入力を受け付ける
         # このとき、キャンセルボタンで巻き戻せるようにする
-        # 諸々正常に完了したら、
+        # 諸々正常に完了したら、それを全体に反映し、確定する
 
 
 class Square:
@@ -519,36 +540,74 @@ class Square:
 
 
 class IBoard(ABC):
+    """盤の抽象クラス"""
     height: int
     width: int
     board: list[list[Square]]
     piece_in_board_index: dict[Controller2P, dict[type[IPiece], set[AbsoluteCoordinate]]]
     piece_stands: dict[Controller2P, Counter[type[IPiece]]]
+
     def __getitem__(self, __key: AbsoluteCoordinate) -> Square:
         return self.board[__key.y][__key.x]
     def __setitem__(self, __key: AbsoluteCoordinate, __value: Any):
         self.board[__key.y][__key.x] = __value
-    def include(self, coord: AbsoluteCoordinate) -> bool:
+
+    def includes(self, coord: AbsoluteCoordinate) -> bool:
+        """座標が盤面の中に入っているかを判定する"""
         return (0 <= coord.y < self.height) and (0 <= coord.x < self.width)
+
+    @staticmethod
+    def square_referer_from_str(referer_str: str) -> AbsoluteCoordinate:
+        """棋譜の表記から座標に変換する"""
+        x, y = referer_str[0], referer_str[1:]
+        return AbsoluteCoordinate(int(y)-1, ord(x)-97)
+
+    @staticmethod
+    def square_referer_to_str(coord: AbsoluteCoordinate) -> str:
+        """座標から棋譜の表記に変換する"""
+        return f"{chr(97+coord.x)}{coord.y+1}"
 
 
 class MatchBoard(IBoard):
     """試合用のボード"""
-    def __init__(self, height: int, width: int, initial_pieces: Iterable[IPiece]) -> None:
+    def __init__(
+            self,
+            height: int,
+            width: int,
+            initial_position: Mapping[AbsoluteCoordinate, IPiece],
+            *,
+            lr_symmetry: bool = False,
+            wb_symmetry: Literal['none', 'face', 'cross'] = 'none',
+        ) -> None:
         self.turn_player = Controller2P.WHITE
         self.height = height
         self.width = width
+        # 駒がない状態の盤面を生成
         self.board = [[Square(None) for _ in range(self.width)] for _ in range(self.height)]
-        for piece in initial_pieces:
-            self[piece.coordinate].piece = piece
         self.piece_stands = {Controller2P.WHITE: Counter(), Controller2P.BLACK: Counter()}
-        self.piece_in_board_index = {Controller2P.WHITE: defaultdict(set), Controller2P.BLACK: defaultdict(set)}
-        for h in range(self.height):
-            for w in range(self.width):
-                coord = AbsoluteCoordinate(h, w)
-                piece = self[coord].piece
-                if piece:
-                    self.piece_in_board_index[piece.controller][type(piece)].add(coord)
+        self.piece_in_board_index = {
+            Controller2P.WHITE: defaultdict(set),
+            Controller2P.BLACK: defaultdict(set),
+        }
+        # initial_piecesを元に盤面に駒を置いていく
+        if lr_symmetry:
+            initial_position_x_inverted = {
+                position.x_inverted.normalize(self): piece for position, piece in initial_position.items()
+            }
+            initial_position = initial_position_x_inverted | initial_position
+        if wb_symmetry == 'face':
+            initial_position_face = {
+                position.y_inverted.normalize(self): type(piece)(piece.controller.next_player()) for position, piece in initial_position.items()
+            }
+            initial_position = initial_position_face | initial_position
+        elif wb_symmetry == 'cross':
+            initial_position_cross = {
+                (~position).normalize(self): type(piece)(piece.controller.next_player()) for position, piece in initial_position.items()
+            }
+            initial_position = initial_position_cross | initial_position
+        for position, piece in initial_position.items():
+            self.add_piece_to_board(type(piece), piece.controller, position)
+        
 
     @property
     def coords_iterator(self):
@@ -559,39 +618,54 @@ class MatchBoard(IBoard):
         """コンソールに盤面を表示する"""
         h_digit = len(str(self.height+1))
         horizontal_line = '-' * (h_digit-1) + '-+' * (self.width+1)
+        column_indicator = ' '*h_digit + '|' + '|'.join(chr(97+w) for w in range(self.width)) + '|'
         print()
-        print(' '*h_digit+'|'+'|'.join(chr(97+w) for w in range(self.width))+'|')
-        for h in range(self.height):
+        print(column_indicator)
+        for h in range(self.height-1, -1, -1):
             print(horizontal_line)
-            print(format(h+1, f'#{h_digit}')+'|'+'|'.join((' ' if not self[AbsoluteCoordinate(h, w)].piece else self[AbsoluteCoordinate(h, w)].piece.SYMBOL_COLORED) for w in range(self.width))+'|')
+            print(format(h+1, f'#{h_digit}')+'|'+'|'.join((
+                ' ' if not self[AbsoluteCoordinate(h, w)].piece
+                else self[AbsoluteCoordinate(h, w)].piece.SYMBOL_COLORED
+            )for w in range(self.width))+'|')
         print(horizontal_line)
 
     def is_game_terminated(self) -> tuple[bool, Controller2P]:
-        """(ゲームが終了したか, 勝者)"""
+        """(ゲームが終了したかの真偽値, 勝者)"""
         loser = set()
         for controller in (Controller2P.WHITE, Controller2P.BLACK):
             if not any(len(v) for (k, v) in self.piece_in_board_index[controller].items() if k.ROYALTY):
                 loser.add(controller)
         if not loser:
-            return (False, Controller2P.ABSENT)
+            return (False, Controller2P.INDEPENDENT)
         if len(loser) == 2:
-            return (True, Controller2P.ABSENT)
+            return (True, Controller2P.INDEPENDENT)
         if Controller2P.WHITE in loser:
             return (True, Controller2P.BLACK)
         if Controller2P.BLACK in loser:
             return (True, Controller2P.WHITE)
-        raise ValueError("something occured")
+        raise ValueError("something unexpected occured")
 
-    def add_piece_to_stand(self, kind: type[IPiece], controller: Controller2P):
+    def add_piece_to_stand(self, kind: type[IPiece], controller: Controller2P) -> None:
         """駒台に駒を置く"""
         self.piece_stands[controller][kind] += 1
 
-    def add_piece_to_board(self, kind: type[IPiece], controller: Controller2P, coord: AbsoluteCoordinate):
+    def add_piece_to_board(
+            self,
+            kind: type[IPiece],
+            controller: Controller2P,
+            coord: AbsoluteCoordinate,
+            *,
+            collision: Literal['raise', 'overwrite', 'skip'] = 'raise',
+        ) -> None:
         """盤面に駒を置く"""
         if self[coord].piece is not None:
-            raise ValueError(f"piece is already in {coord}")
-        self[coord].piece = kind(coord, controller)
+            if collision == 'raise':
+                raise ValueError(f"piece is already in {coord}")
+            if collision == 'skip':
+                return None
+        self[coord].piece = kind(controller)
         self.piece_in_board_index[controller][kind].add(coord)
+        return None
 
     def remove_piece_from_stand(self, kind: type[IPiece], controller: Controller2P):
         """駒台から駒を取り除く"""
@@ -600,24 +674,27 @@ class MatchBoard(IBoard):
             raise ValueError(f"{kind} is not in piece stand")
         active_piece_stand[kind] -= 1
 
-    def remove_piece_from_board(self, coord: AbsoluteCoordinate):
+    def remove_piece_from_board(self, coord: AbsoluteCoordinate) -> None:
         """盤面から駒を取り除く"""
         piece = self[coord].piece
         if not piece:
-            raise ValueError("removing piece is None")
+            raise ValueError("removing piece from None")
         self[coord].piece = None
         self.piece_in_board_index[piece.controller][type(piece)].remove(coord)
 
     def move_destination_from(self, coordinate: AbsoluteCoordinate) -> set[AbsoluteCoordinate]:
-        """移動元の座標から、有効な移動先を返す"""
+        """移動元の座標から、移動先として有効な座標を返す"""
         target_piece = self[coordinate].piece
         if target_piece is None:
             return set()
         return target_piece.valid_destination(self, coordinate)
 
-    def drop_destination(self):
-        """有効な駒を打つ先を返す"""
-        return set(filter(lambda coord: (not self[coord].is_lack) and (self[coord].piece is None), self.coords_iterator))
+    def drop_destination(self) -> set[AbsoluteCoordinate]:
+        """駒を打つ先として有効な座標を返す"""
+        return set(filter(
+            lambda coord: (not self[coord].is_lack) and (self[coord].piece is None),
+            self.coords_iterator,
+        ))
 
     def move(self, depart_coord: AbsoluteCoordinate, arrive_coord: AbsoluteCoordinate):
         """駒を実際に動かす"""
@@ -634,20 +711,26 @@ class MatchBoard(IBoard):
         self.add_piece_to_board(kind, self.turn_player, coord)
         self.remove_piece_from_stand(kind, self.turn_player)
 
+    def promote(self, kind: type[IPiece], coord: AbsoluteCoordinate) -> None:
+        """[coord]の駒が[kind]の駒に成る"""
+        controller = self[coord].piece.controller
+        self.remove_piece_from_board(coord)
+        self.add_piece_to_board(kind, controller, coord)
+
 
     def game(self):
         """試合を行う"""
         while not self.is_game_terminated()[0]:
             self.show_console()
-            starting_coord = set.union(*({square_referer_to_str(k) for k in i} for i in self.piece_in_board_index[self.turn_player].values()))
+            starting_coord = set.union(*({self.square_referer_to_str(k) for k in i} for i in self.piece_in_board_index[self.turn_player].values()))
             while True:
-                depart_coord_str = choose_by_user(starting_coord.union({'cancel'}))
-                if depart_coord_str != 'cancel':
-                    depart_coord = square_referer_from_str(depart_coord_str)
-                    destination = {square_referer_to_str(j) for j in self.move_destination_from(depart_coord)}
-                    arrive_coord_str = choose_by_user(destination.union({'cancel'}))
-                    if arrive_coord_str != 'cancel':
-                        arrive_coord = square_referer_from_str(arrive_coord_str)
+                depart_coord_str = choose_by_user(starting_coord.union({'r'}))
+                if depart_coord_str != 'r':
+                    depart_coord = self.square_referer_from_str(depart_coord_str)
+                    destination = {self.square_referer_to_str(j) for j in self.move_destination_from(depart_coord)}
+                    arrive_coord_str = choose_by_user(destination.union({'r'}))
+                    if arrive_coord_str != 'r':
+                        arrive_coord = self.square_referer_from_str(arrive_coord_str)
                         self.move(depart_coord, arrive_coord)
                         break
                     print("re-selecting...")
@@ -656,38 +739,58 @@ class MatchBoard(IBoard):
         print(f"game end: winner is {self.is_game_terminated()[1]}")
 
 
+
 class King(IPiece):
     NAME = "King"
     MOVE = LeaperMove([RelativeCoordinate(1, 0), RelativeCoordinate(1, 1)], symmetry='oct')
     ROYALTY = True
-    SYMBOL = "k"
+    SYMBOL = 'k'
 
+class Qween(IPiece):
+    NAME = "Qween"
+    MOVE = RiderMove({RelativeCoordinate(1, 0): -1, RelativeCoordinate(1, 1): -1}, symmetry='oct')
+    ROYALTY = False
+    SYMBOL = 'q'
+
+class Bishop(IPiece):
+    NAME = "Bishop"
+    MOVE = RiderMove({RelativeCoordinate(1, 1): -1}, symmetry='fblr')
+    ROYALTY = False
+    SYMBOL = 'b'
 
 class Rook(IPiece):
     NAME = "Rook"
     MOVE = RiderMove({RelativeCoordinate(1, 0): -1}, symmetry='oct')
     ROYALTY = False
-    SYMBOL = "r"
+    SYMBOL = 'r'
 
+class Knight(IPiece):
+    NAME = "Knight"
+    MOVE = LeaperMove([RelativeCoordinate(2, 1)], symmetry='oct')
+    ROYALTY = False
+    SYMBOL = "n"
 
-def square_referer_from_str(referer_str: str) -> AbsoluteCoordinate:
-    x, y = referer_str[0], referer_str[1:]
-    return AbsoluteCoordinate(int(y)-1, ord(x)-97)
-
-def square_referer_to_str(coord: AbsoluteCoordinate) -> str:
-    return f"{chr(97+coord.x)}{coord.y+1}"
+class Pawn(IPiece):
+    NAME = "Pawn"
+    MOVE = LeaperMove([RelativeCoordinate(1, 0)], symmetry='none')
+    ROYALTY = False
+    SYMBOL = "p"
 
 
 if __name__ == '__main__':
     p = {
-        Rook(~AbsoluteCoordinate(0, 0), Controller2P.WHITE),
-        Rook(AbsoluteCoordinate(0, 0), Controller2P.BLACK),
-        King(~AbsoluteCoordinate(0, 2), Controller2P.WHITE),
-        King(AbsoluteCoordinate(0, 2), Controller2P.BLACK),
+        AbsoluteCoordinate(0, 3): King(Controller2P.WHITE),
+        AbsoluteCoordinate(0, 4): Qween(Controller2P.WHITE),
+        AbsoluteCoordinate(0, 0): Rook(Controller2P.WHITE),
+        AbsoluteCoordinate(0, 2): Bishop(Controller2P.WHITE),
+        AbsoluteCoordinate(0, 1): Knight(Controller2P.WHITE),
+        **{AbsoluteCoordinate(1, n): Pawn(Controller2P.WHITE) for n in range(4)},
     }
     play_board = MatchBoard(
-        height=5,
-        width=5,
-        initial_pieces=p,
+        height=8,
+        width=8,
+        initial_position=p,
+        lr_symmetry=True,
+        wb_symmetry='face',
     )
     play_board.game()


### PR DESCRIPTION
カスタム可能な将棋のPython実装(五月祭までの期間を鑑みると最終版になる可能性が高い)

◎JSへの移植に際して変更が必要な部分
○ビジュアライザ
・ターミナル→HTML
・その辺りもカスタムの対象になりそう
○コードでの実装の詳細部分
・各種デコレータの適切な置き換え
・インタフェース関連のクラスの削除

◎実装した機能
○駒の動き方以外
・持ち駒
・成り
・盤面欠け
○駒の動き方
・将棋/チェスの駒はほぼ再現可能
（できないこと：二歩、アンパッサン、打ち歩詰め、ステイルメイト、行き所のない場所へに駒を打つ行為の禁止）